### PR TITLE
[FIX] add middle function to avoid casting errors

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -152,7 +152,7 @@ func BenchmarkUnmarshalYaml(b *testing.B) {
 }
 
 func TestSecret_Decode(t *testing.T) {
-	data := map[interface{}]interface{}{
+	data := map[string]interface{}{
 		"password": "c2VjcmV0",
 		"app":      "a3ViZXJuZXRlcyBzZWNyZXQgZGVjb2Rlcg==",
 	}
@@ -167,7 +167,7 @@ func TestSecret_Decode(t *testing.T) {
 }
 
 func BenchmarkSecret_Decode(b *testing.B) {
-	data := map[interface{}]interface{}{
+	data := map[string]interface{}{
 		"password": "c2VjcmV0",
 		"app":      "a3ViZXJuZXRlcyBzZWNyZXQgZGVjb2Rlcg==",
 	}


### PR DESCRIPTION
this commit is because yaml and json does not support the same decode
output. yaml: map[interface{}]interface{}, json: map[string]interface{}

With these changes, the idea is use always same structure for both
languages. map[string]interface{}

closes #13 